### PR TITLE
fix: Use exit code 0 when there are no changes

### DIFF
--- a/dependencies-update/dependencies-update.sh
+++ b/dependencies-update/dependencies-update.sh
@@ -12,7 +12,7 @@ yarn audit
 
 if git diff-index --quiet HEAD 2>&1; then
   echo "No changes... Bye!"
-  exit
+  exit 0
 fi
 
 # Create a branch on which to commit the changes using the "actions" namespace


### PR DESCRIPTION
I hadn't set the exit code to be used in the event that there are no changes to be committed, which is why we keep seeing scheduled build failures :facepalm: